### PR TITLE
NodeJS v24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x, 22.x, 23.x ]
+        node-version: [ 20.x, 22.x, 24.x ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
- Add NodeJS v24 to build matrix; remove v18 & v23